### PR TITLE
fix rule description; test on IntSliceFunctor

### DIFF
--- a/functor/int_slice.go
+++ b/functor/int_slice.go
@@ -12,7 +12,7 @@ import (
 //	1. f.Map(func(i int) { return i }) == f
 //		- this means that if you map with a function that does nothing (identity), you get the same
 //			thing
-//	2. f.Map(funcA(funcB(param))) == f.Map(funcA).Map(funcB)
+//	2. f.Map(funcB(funcA(param))) == f.Map(funcA).Map(funcB)
 //		- this means that you should be able to compose functions or execute them in serial
 type IntSliceFunctor interface {
 	fmt.Stringer

--- a/functor/int_slice_small_test.go
+++ b/functor/int_slice_small_test.go
@@ -14,3 +14,20 @@ func TestSmallIntSliceFunctor(t *testing.T) {
 	assert.Equal(t, len(mapped.Ints()), len(ints), "resultant ints not the same as original length")
 	assert.Equal(t, mapped.Ints(), ints, "returned int slice")
 }
+
+func TestIntSliceFunctorIntegrity(t *testing.T) {
+	// chaining
+	ints := intSlice(4)
+	functor := LiftIntSlice(ints)
+	m1 := functor.Map(plusOne).Map(timesTwo)
+
+	// function composition
+	ints = intSlice(4)
+	functor = LiftIntSlice(ints)
+	m2 := functor.Map(func(i int) int {
+		return timesTwo(plusOne(i))
+	})
+
+	// compare the results
+	assert.Equal(t, m1.Ints(), m2.Ints(), "returned slices are not equal")
+}

--- a/functor/int_slice_util_test.go
+++ b/functor/int_slice_util_test.go
@@ -14,3 +14,6 @@ func plusOne(i int) int {
 func minusOne(i int) int {
 	return i - 1
 }
+func timesTwo(i int) int {
+	return i * 2
+}


### PR DESCRIPTION
Found this rule on `IntSliceFunctor` description:

```
//	2. f.Map(funcA(funcB(param))) == f.Map(funcA).Map(funcB)
```

That seemed wrong so I added a test and fixed it. Should be:

```
//	2. f.Map(funcB(funcA(param))) == f.Map(funcA).Map(funcB)
```

That way `funcA` is always applied first.