### PR TITLE
eliminate WaitGroup in int_slice_parallel; add benchmark

### DIFF
--- a/functor/int_slice_large_test.go
+++ b/functor/int_slice_large_test.go
@@ -14,3 +14,13 @@ func TestLargeIntSliceFunctor(t *testing.T) {
 	assert.Equal(t, len(mapped.Ints()), len(ints), "resultant ints not the same as original length")
 	assert.Equal(t, mapped.Ints(), ints, "returned int slice")
 }
+
+func BenchmarkLargeIntSliceFunctor(b *testing.B) {
+	ints := intSlice(1000)
+	functor := LiftIntSlice(ints)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		functor.Map(plusOne)
+	}
+}

--- a/functor/int_slice_parallel.go
+++ b/functor/int_slice_parallel.go
@@ -1,9 +1,5 @@
 package functor
 
-import (
-	"sync"
-)
-
 type parallelIntMapperResult struct {
 	idx int
 	val int
@@ -11,19 +7,13 @@ type parallelIntMapperResult struct {
 
 func parallelIntMapper(ints []int, fn func(int) int) []int {
 	ch := make(chan parallelIntMapperResult)
-	var wg sync.WaitGroup
 	for i, elt := range ints {
-		wg.Add(1)
 		go func(idx int, elt int) {
-			defer wg.Done()
 			ch <- parallelIntMapperResult{idx: idx, val: fn(elt)}
 		}(i, elt)
 	}
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-	for elt := range ch {
+	for range ints {
+		elt := <-ch
 		ints[elt.idx] = elt.val
 	}
 	return ints


### PR DESCRIPTION
Simplify parallel computing of `IntSliceFunctor.Map` by eliminating the `sync.WaitGroup`.

Added Benchmark to check for speed regression: No speed regression. No real improvement either.

```sh
benchmark                            old ns/op     new ns/op     delta
BenchmarkLargeIntSliceFunctor-12     487355        474123        -2.72%
```

Could be the usual fluctuation.